### PR TITLE
FIX Reflect updated repo name where referenced in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # SilverStripe Login Forms
 
-[![Build Status](https://api.travis-ci.org/silverstripe/login-forms.svg?branch=master)](https://travis-ci.org/silverstripe/login-forms)
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/silverstripe/login-forms/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/silverstripe/login-forms/?branch=master)
-[![codecov](https://codecov.io/gh/silverstripe/login-forms/branch/master/graph/badge.svg)](https://codecov.io/gh/silverstripe/login-forms)
+[![Build Status](https://api.travis-ci.org/silverstripe/silverstripe-login-forms.svg?branch=master)](https://travis-ci.org/silverstripe/silverstripe-login-forms)
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/silverstripe/silverstripe-login-forms/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/silverstripe/silverstripe-login-forms/?branch=master)
+[![codecov](https://codecov.io/gh/silverstripe/silverstripe-login-forms/branch/master/graph/badge.svg)](https://codecov.io/gh/silverstripe/silverstripe-login-forms)
 [![SilverStripe supported module](https://img.shields.io/badge/silverstripe-supported-0071C4.svg)](https://www.silverstripe.org/software/addons/silverstripe-commercially-supported-module-list/)
 
 ## Overview
 
-The [SilverStripe Login Forms module](https://github.com/silverstripe/login-forms) provides templates for the login screen.
+The [SilverStripe Login Forms module](https://github.com/silverstripe/silverstripe-login-forms) provides templates for the login screen.
 
 ## Requirements
 
@@ -30,4 +30,4 @@ Contributions are welcome! Create an issue, explaining a bug or propose developm
 
 ## Reporting Issues
 
-Please [create an issue](https://github.com/silverstripe/login-forms/issues) for any bugs you've found, or features you're missing.
+Please [create an issue](https://github.com/silverstripe/silverstripe-login-forms/issues) for any bugs you've found, or features you're missing.


### PR DESCRIPTION
The repo name`silverstripe/login-forms` has recently been changed into `silverstripe/silverstripe-login-forms`. Hence the README needed to be updated.

Loosely related to https://github.com/silverstripeltd/cc-issues/issues/193