### PR TITLE
FIX show Message and or Content when necessary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+dist: trusty
+
 matrix:
   include:
     - php: 5.6

--- a/themes/login-forms/templates/Security.ss
+++ b/themes/login-forms/templates/Security.ss
@@ -11,13 +11,22 @@
         <% require css("silverstripe/login-forms: client/dist/styles/bundle.css") %>
     </head>
     <body>
-        <section>
+        <section class="log-in">
             <header>
-                <h1>
+                <h1 class="log-in__site-name">
                     $SiteConfig.Title
                     <% if not $SiteConfig.Title %>SilverStripe<% end_if %>
                 </h1>
             </header>
+            <% if $Message %>
+                <div class="log-in__message
+                    <% if $MessageType && not $AlertType %>log-in__message--$MessageType<% end_if %>
+                    <% if $AlertType %>log-in__message--$AlertType<% end_if %>"
+                >
+                    $Message
+                </div>
+            <% end_if %>
+            <% if $Content && $Content != $Message %><div class="log-in__content">$Content</div><% end_if %>
             $Form
         </section>
         <footer>


### PR DESCRIPTION
Previously important lead in text was being omitted from the final
render shown to the user. This included text about e.g. what to do
next, or why things haven't worked as expected.

`silverstripe/mfa` tests also failed when this module was also installed
as it depended on the output in `$Message` in order to pass a few tests.

Resolves #14.