### PR TITLE
DEP Set PHP 7.4 as the minimum version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "styling"
     ],
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "silverstripe/framework": "^4.10"
     },
     "require-dev": {


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10219
