### PR TITLE
ENH Add config variable to fully disable dark mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,11 @@ since it might change in the future.
 
 The login form includes a dark mode by default for users who prefer it. However,
 if your site is not designed for dark mode yet, you can disable this
-functionality by blocking the stylesheet in `_config.php`:
+functionality by disabling it in your yaml configuration:
 
-```php
-Requirements::block("silverstripe/login-forms: client/dist/styles/darkmode.css");
+```yml
+SilverStripe\Security\Security:
+  enable_dark_mode: false
 ```
 
 ## Contributing

--- a/src/EnablerExtension.php
+++ b/src/EnablerExtension.php
@@ -38,6 +38,8 @@ class EnablerExtension extends Extension
         'ping',
     ];
 
+    private static bool $enable_dark_mode = true;
+
     /**
      * Used to store the value of Security.page_class so that we can temporarily disable it
      * so that Security is used as the Controller instead of Page_Controller
@@ -72,7 +74,7 @@ class EnablerExtension extends Extension
     {
         Config::inst()->set(Security::class, 'page_class', $this->defaultPageClass);
     }
-    
+
     /**
      * Returns an RFC1766 compliant locale string, e.g. 'fr-CA'.
      *
@@ -86,5 +88,10 @@ class EnablerExtension extends Extension
     {
         $locale = i18n::get_locale();
         return i18n::convert_rfc1766($locale);
+    }
+
+    public function darkModeIsEnabled()
+    {
+        return Security::config()->get('enable_dark_mode');
     }
 }

--- a/themes/login-forms/templates/Security.ss
+++ b/themes/login-forms/templates/Security.ss
@@ -8,13 +8,15 @@
             $Metatags.RAW
         <% end_if %>
         <meta name="viewport" content="width=device-width,initial-scale=1.0" />
-        <meta name="color-scheme" content="light dark" />
+        <meta name="color-scheme" content="light <% if $darkModeIsEnabled() %>dark<% else %>only<% end_if %>" />
         <% require css("silverstripe/admin: client/dist/styles/bundle.css") %>
         <% require css("silverstripe/login-forms: client/dist/styles/bundle.css") %>
-        <% require css("silverstripe/login-forms: client/dist/styles/darkmode.css") %>
+        <% if $darkModeIsEnabled() %>
+            <% require css("silverstripe/login-forms: client/dist/styles/darkmode.css") %>
+        <% end_if %>
         <% require javascript("silverstripe/login-forms: client/dist/js/bundle.js") %>
     </head>
-    <body>
+    <body <% if $darkModeIsEnabled() %>class="dark-mode-enabled"<% end_if %>>
         <% include AppHeader %>
 
         <main class="login-form">


### PR DESCRIPTION
Disabling dark mode by removing the stylesheet doesn't disable user-agent dark mode themes and doesn't apply to MFA modules.
This change gives MFA modules a way to identify whether dark mode is enabled or not, and conditionally apply appropriate theming.

## Parent Issue
- https://github.com/silverstripe/silverstripe-mfa/issues/383