### PR TITLE
MNT Ignore vendor dirs when linting sass

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -1,6 +1,7 @@
 # sass-lint config to match the AirBNB style guide
 files:
   include: '**/client/src/**/*.scss'
+  ignore: 'vendor/**/*.scss'
 options:
   formatter: stylish
   merge-default-rules: false


### PR DESCRIPTION
Follow-up to https://github.com/silverstripe/silverstripe-login-forms/pull/116

Fixes [broken js-linting in this job](https://github.com/silverstripe/silverstripe-login-forms/runs/7350266276?check_suite_focus=true)

## Parent issue:
- https://github.com/silverstripe/gha-ci/issues/37