### PR TITLE
BUG: add metatags to template

### DIFF
--- a/src/EnablerExtension.php
+++ b/src/EnablerExtension.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\LoginForms;
 
+use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\View\SSViewer;
 use SilverStripe\Core\Extension;
 use SilverStripe\Security\Security;
@@ -72,7 +73,7 @@ class EnablerExtension extends Extension
 
     public function afterCallActionHandler()
     {
-        Config::inst()->set(Security::class, 'page_class', $this->defaultPageClass);
+        Config::modify()->set(Security::class, 'page_class', $this->defaultPageClass);
     }
 
     /**
@@ -93,5 +94,13 @@ class EnablerExtension extends Extension
     public function darkModeIsEnabled()
     {
         return Security::config()->get('enable_dark_mode');
+    }
+
+    public function MetaTags(?bool $showTitle = true): string
+    {
+        if (class_exists(SiteTree::class)) {
+            return SiteTree::create()->MetaTags($showTitle);
+        }
+        return '';
     }
 }


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->

![image](https://github.com/silverstripe/silverstripe-login-forms/assets/167154/4cb5ea4a-d728-4d44-acbc-f64353b29644)


The `Metatags` listed here return nothing. We should either remove them or link to SiteTree. I have linked to SiteTree here. 

Also, we should be consistent and always talk about `MetaTags`  with two capitals. 

## Manual testing steps
<!--
  Include any manual testing steps here which a reviewer can perform to validate your pull request works correctly.
  Note that this DOES NOT replace unit or end-to-end tests.
-->

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- #

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [ ] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [ ] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [ ] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [ ] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [ ] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [ ] This change is covered with tests (or tests aren't necessary for this change)
- [ ] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [ ] CI is green
