### PR TITLE
FIX #189 - ensure themes are applied for Security::permissionFailure() calls

### DIFF
--- a/src/EnablerExtension.php
+++ b/src/EnablerExtension.php
@@ -75,6 +75,12 @@ class EnablerExtension extends Extension
         Config::inst()->set(Security::class, 'page_class', $this->defaultPageClass);
     }
 
+    public function onBeforeSecurityLogin()
+    {
+        SSViewer::set_themes(Config::inst()->get(EnablerExtension::class, 'login_themes'));
+        Config::modify()->remove(Security::class, 'page_class');
+    }
+
     /**
      * Returns an RFC1766 compliant locale string, e.g. 'fr-CA'.
      *


### PR DESCRIPTION
## Description

This PR addresses issue described in #189 where requests rerouted by `Security::permissionFailure` are not applying this module's theme.


## Manual testing steps
<!--
  Include any manual testing steps here which a reviewer can perform to validate your pull request works correctly.
  Note that this DOES NOT replace unit or end-to-end tests.
-->

See instructions in linked issue

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- https://github.com/silverstripe/silverstripe-login-forms/issues/189

## Pull request checklist

- [ ] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [ ] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [ ] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [ ] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [ ] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [ ] This change is covered with tests (or tests aren't necessary for this change)
- [ ] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [ ] CI is green
