### PR TITLE
FIX Compare routes using lower case

### DIFF
--- a/src/EnablerExtension.php
+++ b/src/EnablerExtension.php
@@ -59,9 +59,12 @@ class EnablerExtension extends Extension
     public function beforeCallActionHandler()
     {
         $config = Config::inst();
-        $action = $this->getOwner()->getAction();
+        // Routes are case-insensitive, so compare everything using lower case
+        $action = strtolower($this->getOwner()->getAction());
         $allowedActions = $config->get(Security::class, 'allowed_actions');
+        $allowedActions = array_map('strtolower', $allowedActions);
         $excludedActions = $config->get(EnablerExtension::class, 'excluded_actions');
+        $excludedActions = array_map('strtolower', $excludedActions);
         $themeActions = array_diff($allowedActions ?? [], $excludedActions);
         if (in_array($action, $themeActions ?? [])) {
             SSViewer::set_themes($config->get(EnablerExtension::class, 'login_themes'));

--- a/tests/php/EnablerExtensionTest.php
+++ b/tests/php/EnablerExtensionTest.php
@@ -30,9 +30,24 @@ class EnablerExtensionTest extends FunctionalTest
         ]);
     }
 
-    public function testThatSecurityActionsHaveUpdatedThemeListApplied()
+    public static function provideThatSecurityActionsHaveUpdatedThemeListApplied(): array
     {
-        $this->get(Security::login_url());
+        return [
+            'regular' => [
+                'url' => '/Security/login'
+            ],
+            'mixed-case' => [
+                'url' => '/Security/lOgIn'
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideThatSecurityActionsHaveUpdatedThemeListApplied
+     */
+    public function testThatSecurityActionsHaveUpdatedThemeListApplied(string $url)
+    {
+        $this->get($url);
         $this->assertContains('silverstripe/login-forms:login-forms', SSViewer::get_themes());
     }
 


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-login-forms/issues/210

Routes are case-insensitive e.g.  /Security/loGin will route to the login form, and /abOut-us will go to the default about-us page