### PR TITLE
ENH Hide font icons from screen readers

### DIFF
--- a/themes/login-forms/templates/SilverStripe/Forms/CheckboxField_holder.ss
+++ b/themes/login-forms/templates/SilverStripe/Forms/CheckboxField_holder.ss
@@ -5,14 +5,16 @@
         <% if $RightTitle %> $RightTitle<% end_if %>
     </label>
     <% if $getAttribute('title') %>
-        <i class="login-form__help-icon font-icon-help-circled"
+        <span class="login-form__help-icon"
            tabindex="0"
            data-bs-toggle="popover"
            data-bs-content="$getAttribute('title')"
            data-bs-trigger="focus"
            data-bs-placement="top"
            data-bs-html="true"
-        ></i>
+        >
+            <span class="font-icon-help-circled" aria-hidden="true"></span>
+        </span>
     <% end_if %>
     <% if $Message %><span class="message $MessageType">$Message</span><% end_if %>
     <% if $Description %><span class="description">$Description</span><% end_if %>


### PR DESCRIPTION
- Replaces any `<i>` being used as an icon with `span` for consistency and semantic correctness
- Hides decorative icons from screen readers (usually by adding an inner `span`)

I didn't notice any visual difference without the admin PR so we don't need to touch the constraints.

## Issue

- https://github.com/silverstripe/silverstripe-admin/issues/1957