### PR TITLE
ENH remove admin dependency in Security.ss

### DIFF
--- a/themes/login-forms/templates/Security.ss
+++ b/themes/login-forms/templates/Security.ss
@@ -9,7 +9,6 @@
         <% end_if %>
         <meta name="viewport" content="width=device-width,initial-scale=1.0" />
         <meta name="color-scheme" content="light <% if $darkModeIsEnabled() %>dark<% else %>only<% end_if %>" />
-        <% require css("silverstripe/admin: client/dist/styles/bundle.css") %>
         <% require css("silverstripe/login-forms: client/dist/styles/bundle.css") %>
         <% if $darkModeIsEnabled() %>
             <% require css("silverstripe/login-forms: client/dist/styles/darkmode.css") %>


### PR DESCRIPTION
## Description
The module doesn't require the admin dependency, therefore the styles can be removed. Changes in styling are minimal, see attached screenshot in PR.
Before:
<img width="1434" height="955" alt="login-pre" src="https://github.com/user-attachments/assets/ee132eda-5ce5-4464-a6c2-3d6ddde39281" />

After:
<img width="1434" height="955" alt="login-post" src="https://github.com/user-attachments/assets/a222c404-e8ea-4b85-a2e9-95b83d790a7b" />


## Manual testing steps

## Issues
- #123 

## Pull request checklist
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green

PR was made during the StripeCon hackathon